### PR TITLE
Fix the estimated DPR to 1 on Wayland.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Crash due to assertion failure on 32-bit architectures
 - Segmentation fault on shutdown with Wayland
+- Incorrect estimated DPR with Wayland
 
 ### Removed
 

--- a/alacritty/src/display/mod.rs
+++ b/alacritty/src/display/mod.rs
@@ -188,9 +188,18 @@ pub struct Display {
 
 impl Display {
     pub fn new<E>(config: &Config, event_loop: &EventLoop<E>) -> Result<Display, Error> {
-        // Guess DPR based on first monitor.
-        let estimated_dpr =
-            event_loop.available_monitors().next().map(|m| m.scale_factor()).unwrap_or(1.);
+        #[cfg(any(not(feature = "x11"), target_os = "macos", windows))]
+        let is_x11 = false;
+        #[cfg(all(feature = "x11", not(any(target_os = "macos", windows))))]
+        let is_x11 = event_loop.is_x11();
+
+        // Guess DPR based on first monitor. On Wayland the initial frame always renders at a DPR
+        // of 1.
+        let estimated_dpr = if cfg!(any(target_os = "macos", windows)) || is_x11 {
+            event_loop.available_monitors().next().map(|m| m.scale_factor()).unwrap_or(1.)
+        } else {
+            1.
+        };
 
         // Guess the target window dimensions.
         let metrics = GlyphCache::static_metrics(config.ui_config.font.clone(), estimated_dpr)?;
@@ -277,11 +286,6 @@ impl Display {
         // Disable shadows for transparent windows on macOS.
         #[cfg(target_os = "macos")]
         window.set_has_shadow(config.ui_config.background_opacity() >= 1.0);
-
-        #[cfg(all(feature = "x11", not(any(target_os = "macos", windows))))]
-        let is_x11 = event_loop.is_x11();
-        #[cfg(not(any(feature = "x11", target_os = "macos", windows)))]
-        let is_x11 = false;
 
         // On Wayland we can safely ignore this call, since the window isn't visible until you
         // actually draw something into it and commit those changes.


### PR DESCRIPTION
On Wayland, regardless of the underlying scale factor for an output, The
scale factor is 1.0 until we receive the first DPRChanged event. To
correctly calculate the window sizes, we must use a DPR of 1.0 as well.

Ideally we would know what the DPR of the window we're being opened in
is going to be, and avoid the estimation guessing game, but that doesn't
seem possible with the current interfaces provided by the window
systems.